### PR TITLE
documentation, css styling, fix slot configuration template

### DIFF
--- a/config/libraries.yaml
+++ b/config/libraries.yaml
@@ -13,13 +13,15 @@ libraryConfig:
   # fashion e.g. Library_0, Library_1,...
   libraryId: "ComdagenSharedLibrary"
 
-  # Total of libraries to be generated
+  # Total of libraries to be generated. First this library will be generated and then the custom libraries up to
+  # "libraryCount"
   libraryCount: 5
 
   # Total number of generated content assets per library
   contentAssetCount: 30
 
-  # Total number of generated folders per library
+  # Total number of generated folders per library. Custom specified folders are generated first followed by default
+  # generated folders up to "folderCount" folders
   folderCount: 10
 
   # Generates a content asset containing the top level seeds and names of all generated libraries and
@@ -78,6 +80,7 @@ libraryConfig:
     - folderId: "root"
       displayName: "Root folder"
       description: "Offers comdagen generated content"
+      # The content of folders marked with onlineFlag false is disabled
       onlineFlag: true
 
   # Creating a custom folder for each entry

--- a/src/test/resources/templates/library.ftlx
+++ b/src/test/resources/templates/library.ftlx
@@ -39,15 +39,16 @@
                    &lt;/ul&gt;
                    &lt;h3&gt;Site statistics:&lt;/h3&gt;
                            <#list comdagensitestats?values as site>
-                               &lt;table&gt;
+                               &lt;table style=&quot;border: black solid 1px; width: auto&quot;&gt;
                                    &lt;tr&gt;
                                <#list site as key, value>
-                                           &lt;th&gt;${key}&lt;/th&gt;
+                                           &lt;th style=&quot;padding: 2px; border: solid black 1px&quot;&gt;${key}&lt;/th&gt;
                                </#list>
                                    &lt;/tr&gt;
                                    &lt;tr&gt;
                                <#list site as key, value>
-                                           &lt;td&gt;${value}&lt;/td&gt;
+                                           &lt;td style=&quot;padding: 2px; border: solid black 1px&quot;&gt;${value}
+                                   &lt;/td&gt;
                                </#list>
                                    &lt;/tr&gt;
                                &lt;/table&gt;
@@ -55,15 +56,16 @@
                            </#list>
                    &lt;h3&gt;Library statistics:&lt;/h3&gt;
                            <#list comdagenlibrarystats?values as site>
-                               &lt;table&gt;
+                               &lt;table style=&quot;border: black solid 1px; width: auto&quot;&gt;
                                    &lt;tr&gt;
                                <#list site as key, value>
-                                           &lt;th&gt;${key}&lt;/th&gt;
+                                           &lt;th style=&quot;padding: 2px; border: solid black 1px&quot;&gt;${key}&lt;/th&gt;
                                </#list>
                                    &lt;/tr&gt;
                                    &lt;tr&gt;
                                <#list site as key, value>
-                                           &lt;td&gt;${value}&lt;/td&gt;
+                                           &lt;td style=&quot;padding: 2px; border: solid black 1px&quot;&gt;${value}
+                                   &lt;/td&gt;
                                </#list>
                                    &lt;/tr&gt;
                                &lt;/table&gt;

--- a/templates/static/slots.xml
+++ b/templates/static/slots.xml
@@ -125,9 +125,10 @@ Here you will find answers to your questions about shopping at our online store,
         </content>
     </slot-configuration>
 
-    <slot-configuration slot-id="home-main" context="global" configuration-id="homepage-jquery-cycle" default="true" assigned-to-site="true">
-        <description>Homepage Jquery Cycle</description>
-        <template>slots/content/homepage/homepageslider.isml</template>
+    <slot-configuration slot-id="home-main" context="global" configuration-id="comdagen-summary-cid" default="true"
+                        assigned-to-site="true">
+        <description>Comdagen summary slot</description>
+        <template>slots/content/contentassetbody.isml</template>
         <enabled-flag>true</enabled-flag>
         <content>
             <content-assets>


### PR DESCRIPTION
Improved comments in config; enhanced css styling on comdagen summary
content asset; "home-main" content asset slot uses the comdagen summary
with the contentassetbody.isml template now