### PR TITLE
Fixing obsolete preference; formatting change

### DIFF
--- a/src/test/resources/templates/preferences.ftlx
+++ b/src/test/resources/templates/preferences.ftlx
@@ -16,7 +16,7 @@
             <preference preference-id="OrderExportDelay">30</preference>
             <preference preference-id="OrderIPLoggingEnabled">true</preference>
             <preference preference-id="OrderLifetime">0</preference>
-            <preference preference-id="PaymentAccountNumberLifetime">0</preference>
+            <preference preference-id="AccountNumberRetentionDays">0</preference>
             <preference preference-id="ProductChangeFrequency">daily</preference>
             <preference preference-id="ProductPriority">0.5</preference>
             <#if catalogs??>

--- a/templates/preferences.ftlx
+++ b/templates/preferences.ftlx
@@ -16,12 +16,10 @@
             <preference preference-id="OrderExportDelay">30</preference>
             <preference preference-id="OrderIPLoggingEnabled">true</preference>
             <preference preference-id="OrderLifetime">0</preference>
-            <preference preference-id="PaymentAccountNumberLifetime">0</preference>
+            <preference preference-id="AccountNumberRetentionDays">0</preference>
             <preference preference-id="ProductChangeFrequency">daily</preference>
             <preference preference-id="ProductPriority">0.5</preference>
-            <#if navigationCatalog??>
-            <preference preference-id="SiteCatalog">${navigationCatalog}</preference>
-            </#if>
+            <#if navigationCatalog??><preference preference-id="SiteCatalog">${navigationCatalog}</preference></#if>
             <#if currencies??>
             <preference preference-id="SiteCurrencies">${currencies?join(":")}</preference>
             </#if>


### PR DESCRIPTION
Fixed obsolete preference PaymentAccountNumberLifetime by using AccountNumberRetentionDays; Fixing SiteCatalog indentation.

Signed-off-by: Moritz Müller <moritz.mueller@salesforce.com>