### PR TITLE
ci: run Maven tests on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 8
+          cache: maven
+
+      - name: Build and test
+        run: mvn -B verify


### PR DESCRIPTION
Add a GitHub Actions workflow that runs `mvn -B verify` on JDK 8 for every pull request and push to master, so regressions are caught before merge.