### PR TITLE
ci: run on every pushed branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ name: CI
 on:
   pull_request:
   push:
-    branches: [master]
 
 jobs:
   test:


### PR DESCRIPTION
Drop the master-only push filter so CI runs on every branch push, not just master. Pull request runs are unchanged.