### PR TITLE
chore: update dependencies to latest stable versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <properties>
         <kotlin.version>1.9.25</kotlin.version>
-        <jackson.version>2.11.0</jackson.version>
+        <jackson.version>2.18.4</jackson.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>17</maven.compiler.release>
         <kotlin.compiler.jvmTarget>17</kotlin.compiler.jvmTarget>
@@ -29,28 +29,28 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>1.7.25</version>
+            <version>2.0.17</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.25</version>
+            <version>2.0.17</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>32.0.0-jre</version>
+            <version>33.6.0-jre</version>
         </dependency>
         <dependency>
             <groupId>args4j</groupId>
             <artifactId>args4j</artifactId>
-            <version>2.33</version>
+            <version>2.37</version>
         </dependency>
         <dependency>
             <groupId>org.freemarker</groupId>
             <artifactId>freemarker</artifactId>
-            <version>2.3.28</version>
+            <version>2.3.34</version>
         </dependency>
 
         <dependency>
@@ -68,25 +68,25 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.18.0</version>
+            <version>3.20.0</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/junit/junit -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>5.1.0</version>
+            <version>5.12.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.xmlunit</groupId>
             <artifactId>xmlunit-matchers</artifactId>
-            <version>2.5.0</version>
+            <version>2.11.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.natpryce</groupId>
             <artifactId>hamkrest</artifactId>
-            <version>1.4.2.2</version>
+            <version>1.8.0.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -103,12 +103,12 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.26.0</version>
+            <version>1.28.0</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk15on</artifactId>
-            <version>1.67</version>
+            <artifactId>bcprov-jdk18on</artifactId>
+            <version>1.80</version>
         </dependency>
     </dependencies>
 
@@ -117,7 +117,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>2.10</version>
+                <version>3.10.0</version>
                 <executions>
                     <execution>
                         <id>copy-dependencies</id>
@@ -152,7 +152,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.13.0</version>
+                <version>3.14.0</version>
                 <executions>
                     <execution>
                         <id>compile</id>
@@ -173,7 +173,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.6.2</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -207,9 +207,11 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.5.4</version>
+                <version>3.7.1</version>
                 <configuration>
-                    <descriptor>src/assembly/assembly.xml</descriptor>
+                    <descriptors>
+                        <descriptor>src/assembly/assembly.xml</descriptor>
+                    </descriptors>
                 </configuration>
                 <executions>
                     <execution>

--- a/src/main/java/com/salesforce/comdagen/Comdagen.kt
+++ b/src/main/java/com/salesforce/comdagen/Comdagen.kt
@@ -176,7 +176,7 @@ class Comdagen {
 
         /** Used for parsing the generator config files.  */
         val OBJECT_MAPPER = ObjectMapper(YAMLFactory())
-            .registerModule(KotlinModule())
+            .registerModule(KotlinModule.Builder().build())
             .addMixIn(Configuration::class.java, SeedInheritanceMixin::class.java)
             .configure(DeserializationFeature.UNWRAP_ROOT_VALUE, true)
 


### PR DESCRIPTION
- slf4j 1.7.25 -> 2.0.17
- guava 32.0.0-jre -> 33.6.0-jre
- args4j 2.33 -> 2.37
- freemarker 2.3.28 -> 2.3.34
- jackson 2.11.0 -> 2.18.4
- commons-lang3 3.18.0 -> 3.20.0
- commons-compress 1.26.0 -> 1.28.0
- junit-jupiter-api 5.1.0 -> 5.12.2
- xmlunit-matchers 2.5.0 -> 2.11.0
- hamkrest 1.4.2.2 -> 1.8.0.1
- bcprov-jdk15on 1.67 -> bcprov-jdk18on 1.80
- maven-dependency-plugin 2.10 -> 3.10.0
- maven-compiler-plugin 3.13.0 -> 3.14.0
- maven-shade-plugin 3.1.0 -> 3.6.2
- maven-assembly-plugin 2.5.4 -> 3.7.1

Switch KotlinModule() to KotlinModule.Builder().build() since the no-arg constructor is private in Jackson >= 2.12.