### PR TITLE
ci: smoke-test the shaded jar against the default config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,3 +19,10 @@ jobs:
 
       - name: Build and test
         run: mvn -B verify
+
+      - name: Smoke test — generate data set with default config
+        run: |
+          JAR=$(ls target/comdagen-*-SNAPSHOT.jar | grep -v '/original-' | head -1)
+          java -jar "$JAR" --zip
+          test -s output/generated.zip
+          unzip -l output/generated.zip | tail -20


### PR DESCRIPTION
Run the packaged jar with --zip after mvn verify and assert the output zip is non-empty. Catches runtime regressions (template, reflection, serialization) that unit tests miss.