### PR TITLE
chore: migrate tests from JUnit 4 to JUnit 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.12.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.xmlunit</groupId>
             <artifactId>xmlunit-matchers</artifactId>
             <version>2.11.0</version>
@@ -96,7 +102,7 @@
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-test-junit</artifactId>
+            <artifactId>kotlin-test-junit5</artifactId>
             <version>${kotlin.version}</version>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,18 @@
         <kotlin.compiler.jvmTarget>17</kotlin.compiler.jvmTarget>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>5.12.2</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/src/test/java/com/salesforce/comdagen/CatalogTest.kt
+++ b/src/test/java/com/salesforce/comdagen/CatalogTest.kt
@@ -10,7 +10,8 @@ import com.salesforce.comdagen.model.AttributeDefinition
 import com.salesforce.comdagen.model.Category
 import com.salesforce.comdagen.model.Product
 import com.salesforce.comdagen.model.ProductOption
-import org.junit.Test
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
@@ -259,14 +260,18 @@ class CatalogTest {
         }
     }
 
-    @Test(expected = IllegalArgumentException::class)
+    @Test
     fun testVariantConfigProbabilityEnforced() {
-        VariationAttributeConfiguration("test", listOf("1"), 2.0f)
+        assertThrows<IllegalArgumentException> {
+            VariationAttributeConfiguration("test", listOf("1"), 2.0f)
+        }
     }
 
-    @Test(expected = IllegalArgumentException::class)
+    @Test
     fun testVariantConfigNegativeProbabilityRejected() {
-        VariationAttributeConfiguration("test", listOf("1"), -1.4f)
+        assertThrows<IllegalArgumentException> {
+            VariationAttributeConfiguration("test", listOf("1"), -1.4f)
+        }
     }
 
     @Test

--- a/src/test/java/com/salesforce/comdagen/CouponTest.kt
+++ b/src/test/java/com/salesforce/comdagen/CouponTest.kt
@@ -5,7 +5,7 @@ import com.salesforce.comdagen.config.SystemCodeConfig
 import com.salesforce.comdagen.generator.CouponGenerator
 import com.salesforce.comdagen.model.CodeListCoupon
 import com.salesforce.comdagen.model.SystemCodeCoupon
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals

--- a/src/test/java/com/salesforce/comdagen/CustomerAttributeTest.kt
+++ b/src/test/java/com/salesforce/comdagen/CustomerAttributeTest.kt
@@ -2,7 +2,7 @@ package com.salesforce.comdagen
 
 import com.salesforce.comdagen.config.GeneratedAttributeConfig
 import com.salesforce.comdagen.model.RandomAttributeDefinition
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.util.*
 import kotlin.test.assertEquals
 

--- a/src/test/java/com/salesforce/comdagen/CustomerGroupTest.kt
+++ b/src/test/java/com/salesforce/comdagen/CustomerGroupTest.kt
@@ -5,7 +5,7 @@ import com.salesforce.comdagen.config.CustomerConfiguration
 import com.salesforce.comdagen.config.CustomerGroupConfiguration
 import com.salesforce.comdagen.config.GeneratedAttributeConfig
 import com.salesforce.comdagen.generator.CustomerGroupGenerator
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue

--- a/src/test/java/com/salesforce/comdagen/CustomerTest.kt
+++ b/src/test/java/com/salesforce/comdagen/CustomerTest.kt
@@ -5,7 +5,7 @@ import com.salesforce.comdagen.config.CustomerConfiguration
 import com.salesforce.comdagen.config.GeneratedAttributeConfig
 import com.salesforce.comdagen.generator.CustomerGenerator
 import com.salesforce.comdagen.model.Customer
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.*
 
 class CustomerTest {

--- a/src/test/java/com/salesforce/comdagen/InventoryTest.kt
+++ b/src/test/java/com/salesforce/comdagen/InventoryTest.kt
@@ -8,7 +8,7 @@ import com.salesforce.comdagen.config.InventoryRecordConfiguration
 import com.salesforce.comdagen.config.ProductConfiguration
 import com.salesforce.comdagen.generator.CatalogGenerator
 import com.salesforce.comdagen.generator.InventoryGenerator
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue

--- a/src/test/java/com/salesforce/comdagen/LibraryTest.kt
+++ b/src/test/java/com/salesforce/comdagen/LibraryTest.kt
@@ -5,19 +5,18 @@ import com.salesforce.comdagen.config.ContentConfiguration
 import com.salesforce.comdagen.config.FolderConfiguration
 import com.salesforce.comdagen.config.LibraryConfiguration
 import com.salesforce.comdagen.generator.LibraryGenerator
-import org.junit.Rule
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
-import org.junit.rules.TemporaryFolder
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class LibraryTest {
 
-    @Rule
-    @JvmField
-    val tmpFolder = TemporaryFolder()
+    @TempDir
+    lateinit var tmpFolder: File
 
     @Test
     fun `default configuration tests`() {
@@ -56,7 +55,7 @@ class LibraryTest {
         )
 
 
-        val libraryGenerator = LibraryGenerator(defaultLibraryConfig, tmpFolder.root)
+        val libraryGenerator = LibraryGenerator(defaultLibraryConfig, tmpFolder)
         val libraryObjects = libraryGenerator.objects
 
 
@@ -176,7 +175,7 @@ class LibraryTest {
         )
 
 
-        val libraryGenerator = LibraryGenerator(defaultLibraryConfig, tmpFolder.root)
+        val libraryGenerator = LibraryGenerator(defaultLibraryConfig, tmpFolder)
         val libraryObjects = libraryGenerator.objects
 
         assertTrue(
@@ -328,7 +327,7 @@ class LibraryTest {
         )
 
 
-        val libraryGenerator = LibraryGenerator(defaultLibraryConfig, tmpFolder.root)
+        val libraryGenerator = LibraryGenerator(defaultLibraryConfig, tmpFolder)
         val libraryObjects = libraryGenerator.objects
 
         assertTrue(
@@ -387,7 +386,7 @@ class LibraryTest {
         )
 
 
-        val libraryGenerator2 = LibraryGenerator(defaultLibraryConfig2, tmpFolder.root)
+        val libraryGenerator2 = LibraryGenerator(defaultLibraryConfig2, tmpFolder)
         val libraryObjects2 = libraryGenerator2.objects
 
         assertTrue(

--- a/src/test/java/com/salesforce/comdagen/PricebookTest.kt
+++ b/src/test/java/com/salesforce/comdagen/PricebookTest.kt
@@ -4,7 +4,7 @@ import com.salesforce.comdagen.config.*
 import com.salesforce.comdagen.generator.CatalogGenerator
 import com.salesforce.comdagen.generator.PricebookGenerator
 import com.salesforce.comdagen.model.Amount
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals

--- a/src/test/java/com/salesforce/comdagen/PromotionTest.kt
+++ b/src/test/java/com/salesforce/comdagen/PromotionTest.kt
@@ -6,7 +6,7 @@ import com.salesforce.comdagen.model.CampaignPromotionAssignment
 import com.salesforce.comdagen.model.OrderPromotion
 import com.salesforce.comdagen.model.ProductPromotion
 import com.salesforce.comdagen.model.ShippingPromotion
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 

--- a/src/test/java/com/salesforce/comdagen/RedirectUrlTest.kt
+++ b/src/test/java/com/salesforce/comdagen/RedirectUrlTest.kt
@@ -7,7 +7,7 @@ import com.salesforce.comdagen.generator.RedirectUrlGenerator
 import com.salesforce.comdagen.model.CategoryRedirectUrl
 import com.salesforce.comdagen.model.ProductRedirectUrl
 import com.salesforce.comdagen.model.StaticRedirectUrl
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.*
 
 class RedirectUrlTest {

--- a/src/test/java/com/salesforce/comdagen/SchemaVerificationTest.kt
+++ b/src/test/java/com/salesforce/comdagen/SchemaVerificationTest.kt
@@ -3,9 +3,8 @@ package com.salesforce.comdagen
 import com.salesforce.comdagen.config.*
 import com.salesforce.comdagen.generator.*
 import com.salesforce.comdagen.model.AttributeDefinition
-import org.junit.Rule
-import org.junit.Test
-import org.junit.rules.TemporaryFolder
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
 import org.xmlunit.validation.Languages
 import java.io.File
 import java.nio.file.Files
@@ -25,13 +24,11 @@ class SchemaVerificationTest {
         private val seed: Long = 1234
     }
 
-    @Rule
-    @JvmField
-    val inputDir = TemporaryFolder()
+    @TempDir
+    lateinit var inputDir: File
 
-    @Rule
-    @JvmField
-    val outputDir = TemporaryFolder()
+    @TempDir
+    lateinit var outputDir: File
 
     @Test
     fun testCustomerValid() {
@@ -41,20 +38,20 @@ class SchemaVerificationTest {
         val v = getValidator("/schema/customerlist2.xsd")
 
         val templateFileName = "customers.ftlx"
-        val template = inputDir.newFile(templateFileName)
+        val template = File(inputDir, templateFileName)
         Files.copy(
             javaClass.getResourceAsStream("/templates/$templateFileName"), template.toPath(),
             StandardCopyOption.REPLACE_EXISTING
         )
 
-        val producer = XMLOutputProducer(inputDir.root, outputDir.root)
+        val producer = XMLOutputProducer(inputDir, outputDir)
         producer.render(customerGenerator)
         assertTrue {
             try {
                 v.validate(
                     StreamSource(
                         File(
-                            outputDir.root,
+                            outputDir,
                             "${customerConfig.outputDir}/${customerConfig.getFileName()}"
                         )
                     )
@@ -76,13 +73,13 @@ class SchemaVerificationTest {
         val v = getValidator("/schema/pricebook.xsd")
 
         val templateFileName = "pricebooks.ftlx"
-        val template = inputDir.newFile(templateFileName)
+        val template = File(inputDir, templateFileName)
         Files.copy(
             javaClass.getResourceAsStream("/templates/$templateFileName"), template.toPath(),
             StandardCopyOption.REPLACE_EXISTING
         )
 
-        val producer = XMLOutputProducer(inputDir.root, outputDir.root)
+        val producer = XMLOutputProducer(inputDir, outputDir)
         producer.render(pricebookGenerator)
 
         assertTrue {
@@ -90,7 +87,7 @@ class SchemaVerificationTest {
                 v.validate(
                     StreamSource(
                         File(
-                            outputDir.root,
+                            outputDir,
                             "${pricebookConfig.outputDir}/${pricebookConfig.getFileName()}"
                         )
                     )
@@ -113,13 +110,13 @@ class SchemaVerificationTest {
         val v = getValidator("/schema/catalog.xsd")
 
         val templateFileName = "catalogs.ftlx"
-        val template = inputDir.newFile(templateFileName)
+        val template = File(inputDir, templateFileName)
         Files.copy(
             javaClass.getResourceAsStream("/templates/$templateFileName"), template.toPath(),
             StandardCopyOption.REPLACE_EXISTING
         )
 
-        val producer = XMLOutputProducer(inputDir.root, outputDir.root)
+        val producer = XMLOutputProducer(inputDir, outputDir)
         producer.render(catalogGenerator)
 
         assertTrue {
@@ -127,7 +124,7 @@ class SchemaVerificationTest {
                 v.validate(
                     StreamSource(
                         File(
-                            outputDir.root,
+                            outputDir,
                             "${catalogConfig.outputDir}/$catalogId/${catalogConfig.outputFilePattern}"
                         )
                     )
@@ -152,13 +149,13 @@ class SchemaVerificationTest {
         val v = getValidator("/schema/inventory.xsd")
 
         val templateFileName = "inventories.ftlx"
-        val template = inputDir.newFile(templateFileName)
+        val template = File(inputDir, templateFileName)
         Files.copy(
             javaClass.getResourceAsStream("/templates/$templateFileName"), template.toPath(),
             StandardCopyOption.REPLACE_EXISTING
         )
 
-        val producer = XMLOutputProducer(inputDir.root, outputDir.root)
+        val producer = XMLOutputProducer(inputDir, outputDir)
         producer.render(inventoryGenerator)
 
         assertTrue {
@@ -166,7 +163,7 @@ class SchemaVerificationTest {
                 v.validate(
                     StreamSource(
                         File(
-                            outputDir.root,
+                            outputDir,
                             "${inventoryConfig.outputDir}/${inventoryConfig.getFileName()}"
                         )
                     )
@@ -187,13 +184,13 @@ class SchemaVerificationTest {
         val v = getValidator("/schema/coupon.xsd")
 
         val templateFileName = "coupons.ftlx"
-        val template = inputDir.newFile(templateFileName)
+        val template = File(inputDir, templateFileName)
         Files.copy(
             javaClass.getResourceAsStream("/templates/$templateFileName"), template.toPath(),
             StandardCopyOption.REPLACE_EXISTING
         )
 
-        val producer = XMLOutputProducer(inputDir.root, outputDir.root)
+        val producer = XMLOutputProducer(inputDir, outputDir)
         producer.render(couponGenerator)
 
         assertTrue {
@@ -201,7 +198,7 @@ class SchemaVerificationTest {
                 v.validate(
                     StreamSource(
                         File(
-                            outputDir.root,
+                            outputDir,
                             "${couponConfig.outputDir}/${couponConfig.outputFilePattern}"
                         )
                     )
@@ -223,13 +220,13 @@ class SchemaVerificationTest {
         val v = getValidator("/schema/customergroup.xsd")
 
         val templateFileName = "customer-groups.ftlx"
-        val template = inputDir.newFile(templateFileName)
+        val template = File(inputDir, templateFileName)
         Files.copy(
             javaClass.getResourceAsStream("/templates/$templateFileName"), template.toPath(),
             StandardCopyOption.REPLACE_EXISTING
         )
 
-        val producer = XMLOutputProducer(inputDir.root, outputDir.root)
+        val producer = XMLOutputProducer(inputDir, outputDir)
         producer.render(customerGroupGenerator)
 
         assertTrue {
@@ -237,7 +234,7 @@ class SchemaVerificationTest {
                 v.validate(
                     StreamSource(
                         File(
-                            outputDir.root,
+                            outputDir,
                             "${customerGroupConfig.outputDir}/${customerGroupConfig.outputFilePattern}"
                         )
                     )
@@ -275,17 +272,17 @@ class SchemaVerificationTest {
         val searchSchema = getValidator("/schema/search2.xsd")
 
         val templateFileName = "system-objecttype-extensions.ftlx"
-        val template = inputDir.newFile(templateFileName)
+        val template = File(inputDir, templateFileName)
         Files.copy(
             javaClass.getResourceAsStream("/templates/$templateFileName"), template.toPath(),
             StandardCopyOption.REPLACE_EXISTING
         )
         Files.copy(
-            javaClass.getResourceAsStream("/templates/search2.ftlx"), inputDir.newFile("search2.ftlx").toPath(),
+            javaClass.getResourceAsStream("/templates/search2.ftlx"), File(inputDir, "search2.ftlx").toPath(),
             StandardCopyOption.REPLACE_EXISTING
         )
 
-        val producer = XMLOutputProducer(inputDir.root, outputDir.root)
+        val producer = XMLOutputProducer(inputDir, outputDir)
 
         val customAttributes: Map<String, Set<AttributeDefinition>> =
             catalogGenerator.metadata + pricebookGenerator.metadata + customerGenerator.metadata
@@ -294,8 +291,8 @@ class SchemaVerificationTest {
 
         assertTrue {
             try {
-                v.validate(StreamSource(File(outputDir.root, "meta/system-objecttype-extensions.xml")))
-                searchSchema.validate(StreamSource(File(outputDir.root, "search2.xml")))
+                v.validate(StreamSource(File(outputDir, "meta/system-objecttype-extensions.xml")))
+                searchSchema.validate(StreamSource(File(outputDir, "search2.xml")))
                 return@assertTrue true
             } catch (e: Exception) {
                 e.printStackTrace()
@@ -329,13 +326,13 @@ class SchemaVerificationTest {
         val v = getValidator("/schema/promotion.xsd")
 
         val templateFileName = "promotions.ftlx"
-        val template = inputDir.newFile(templateFileName)
+        val template = File(inputDir, templateFileName)
         Files.copy(
             javaClass.getResourceAsStream("/templates/$templateFileName"), template.toPath(),
             StandardCopyOption.REPLACE_EXISTING
         )
 
-        val producer = XMLOutputProducer(inputDir.root, outputDir.root)
+        val producer = XMLOutputProducer(inputDir, outputDir)
 
         producer.render(promotionGenerator)
 
@@ -344,7 +341,7 @@ class SchemaVerificationTest {
                 v.validate(
                     StreamSource(
                         File(
-                            outputDir.root,
+                            outputDir,
                             "${promotionConfig.outputDir}/${promotionConfig.outputFilePattern}"
                         )
                     )
@@ -365,19 +362,19 @@ class SchemaVerificationTest {
         val v = getValidator("/schema/shipping.xsd")
 
         val templateFileName = "shipping.ftlx"
-        val template = inputDir.newFile(templateFileName)
+        val template = File(inputDir, templateFileName)
         Files.copy(
             javaClass.getResourceAsStream("/templates/$templateFileName"), template.toPath(),
             StandardCopyOption.REPLACE_EXISTING
         )
 
-        val producer = XMLOutputProducer(inputDir.root, outputDir.root)
+        val producer = XMLOutputProducer(inputDir, outputDir)
 
         producer.render(shippingGenerator)
 
         assertTrue {
             try {
-                v.validate(StreamSource(File(outputDir.root, shippingConfig.outputFilePattern)))
+                v.validate(StreamSource(File(outputDir, shippingConfig.outputFilePattern)))
                 return@assertTrue true
             } catch (e: Exception) {
                 e.printStackTrace()
@@ -394,19 +391,19 @@ class SchemaVerificationTest {
         val v = getValidator("/schema/store.xsd")
 
         val templateFileName = "stores.ftlx"
-        val template = inputDir.newFile(templateFileName)
+        val template = File(inputDir, templateFileName)
         Files.copy(
             javaClass.getResourceAsStream("/templates/$templateFileName"), template.toPath(),
             StandardCopyOption.REPLACE_EXISTING
         )
 
-        val producer = XMLOutputProducer(inputDir.root, outputDir.root)
+        val producer = XMLOutputProducer(inputDir, outputDir)
 
         producer.render(storeGenerator)
 
         assertTrue {
             try {
-                v.validate(StreamSource(File(outputDir.root, storeConfig.outputFilePattern)))
+                v.validate(StreamSource(File(outputDir, storeConfig.outputFilePattern)))
                 return@assertTrue true
             } catch (e: Exception) {
                 e.printStackTrace()
@@ -423,19 +420,19 @@ class SchemaVerificationTest {
         val v = getValidator("/schema/sort.xsd")
 
         val templateFileName = "sortingrules.ftlx"
-        val template = inputDir.newFile(templateFileName)
+        val template = File(inputDir, templateFileName)
         Files.copy(
             javaClass.getResourceAsStream("/templates/$templateFileName"), template.toPath(),
             StandardCopyOption.REPLACE_EXISTING
         )
 
-        val producer = XMLOutputProducer(inputDir.root, outputDir.root)
+        val producer = XMLOutputProducer(inputDir, outputDir)
 
         producer.render(sortingRuleGenerator)
 
         assertTrue {
             try {
-                v.validate(StreamSource(File(outputDir.root, sortingRuleConfig.outputFilePattern)))
+                v.validate(StreamSource(File(outputDir, sortingRuleConfig.outputFilePattern)))
                 return@assertTrue true
             } catch (e: Exception) {
                 e.printStackTrace()
@@ -457,19 +454,19 @@ class SchemaVerificationTest {
         val v = getValidator("/schema/redirecturl.xsd")
 
         val templateFileName = "redirect-urls.ftlx"
-        val template = inputDir.newFile(templateFileName)
+        val template = File(inputDir, templateFileName)
         Files.copy(
             javaClass.getResourceAsStream("/templates/$templateFileName"), template.toPath(),
             StandardCopyOption.REPLACE_EXISTING
         )
 
-        val producer = XMLOutputProducer(inputDir.root, outputDir.root)
+        val producer = XMLOutputProducer(inputDir, outputDir)
 
         producer.render(redirectUrlGenerator)
 
         assertTrue {
             try {
-                v.validate(StreamSource(File(outputDir.root, redirectUrlConfig.outputFilePattern)))
+                v.validate(StreamSource(File(outputDir, redirectUrlConfig.outputFilePattern)))
                 return@assertTrue true
             } catch (e: Exception) {
                 e.printStackTrace()

--- a/src/test/java/com/salesforce/comdagen/SeedInheritanceTest.kt
+++ b/src/test/java/com/salesforce/comdagen/SeedInheritanceTest.kt
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.databind.ObjectReader
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import com.salesforce.InvalidSpecificationException
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.fail
 
 class SeedInheritanceTest {

--- a/src/test/java/com/salesforce/comdagen/ShippingTest.kt
+++ b/src/test/java/com/salesforce/comdagen/ShippingTest.kt
@@ -4,7 +4,7 @@ import com.salesforce.comdagen.config.AttributeConfig
 import com.salesforce.comdagen.config.GeneratedAttributeConfig
 import com.salesforce.comdagen.config.ShippingConfiguration
 import com.salesforce.comdagen.generator.ShippingGenerator
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 

--- a/src/test/java/com/salesforce/comdagen/SiteTest.kt
+++ b/src/test/java/com/salesforce/comdagen/SiteTest.kt
@@ -6,19 +6,21 @@ import com.natpryce.hamkrest.hasSize
 import com.salesforce.comdagen.config.SiteConfiguration
 import com.salesforce.comdagen.config.SitesConfig
 import com.salesforce.comdagen.generator.SiteGenerator
-import org.junit.Rule
-import org.junit.Test
-import org.junit.rules.TemporaryFolder
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
 import kotlin.test.assertNull
 
 class SiteTest {
-    @Rule
-    @JvmField
-    val testFolder = TemporaryFolder()
+    @TempDir
+    lateinit var testFolder: File
 
-    @Test(expected = IllegalArgumentException::class)
+    @Test
     fun `no site specified errors`() {
-        SitesConfig(elementCount = 0, defaults = null)
+        assertThrows<IllegalArgumentException> {
+            SitesConfig(elementCount = 0, defaults = null)
+        }
     }
 
     @Test
@@ -27,7 +29,7 @@ class SiteTest {
         val generator =
             SiteGenerator(
                 config,
-                testFolder.root /* nothing in here, but we also have no config files specified */,
+                testFolder /* nothing in here, but we also have no config files specified */,
                 false
             )
 
@@ -40,7 +42,7 @@ class SiteTest {
     @Test
     fun `can generate multiple random sites`() {
         val config = SitesConfig(elementCount = 3, initialSeed = 123, defaults = SiteConfiguration("random"))
-        val generator = SiteGenerator(config, testFolder.root, false)
+        val generator = SiteGenerator(config, testFolder, false)
 
         val sites = generator.objects.toList()
         assertThat(sites, hasSize(equalTo(3)))
@@ -57,7 +59,7 @@ class SiteTest {
             sites = listOf(SiteConfiguration("First")),
             defaults = null
         )
-        val generator = SiteGenerator(config, testFolder.root, false)
+        val generator = SiteGenerator(config, testFolder, false)
 
         val sites = generator.objects.toList()
         assertThat(sites, hasSize(equalTo(1)))
@@ -70,7 +72,7 @@ class SiteTest {
             elementCount = 1, initialSeed = 123, sites = listOf(SiteConfiguration("First")),
             defaults = SiteConfiguration("Doesn't matter", "My site")
         )
-        val generator = SiteGenerator(config, testFolder.root, false)
+        val generator = SiteGenerator(config, testFolder, false)
 
         val sites = generator.objects.toList()
         assertThat(sites, hasSize(equalTo(1)))
@@ -85,7 +87,7 @@ class SiteTest {
             defaults = SiteConfiguration("random", "My site")
         )
 
-        val generator = SiteGenerator(config, testFolder.root, false)
+        val generator = SiteGenerator(config, testFolder, false)
 
         val sites = generator.objects.toList()
         assertThat(sites, hasSize(equalTo(2)))

--- a/src/test/java/com/salesforce/comdagen/SortingRuleTest.kt
+++ b/src/test/java/com/salesforce/comdagen/SortingRuleTest.kt
@@ -2,7 +2,7 @@ package com.salesforce.comdagen
 
 import com.salesforce.comdagen.config.SortingRuleConfiguration
 import com.salesforce.comdagen.generator.SortingRuleGenerator
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 

--- a/src/test/java/com/salesforce/comdagen/SourceCodeTest.kt
+++ b/src/test/java/com/salesforce/comdagen/SourceCodeTest.kt
@@ -4,7 +4,7 @@ import com.salesforce.comdagen.config.AttributeConfig
 import com.salesforce.comdagen.config.GeneratedAttributeConfig
 import com.salesforce.comdagen.config.SourceCodeConfiguration
 import com.salesforce.comdagen.generator.SourceCodeGenerator
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 

--- a/src/test/java/com/salesforce/comdagen/StoreTest.kt
+++ b/src/test/java/com/salesforce/comdagen/StoreTest.kt
@@ -4,7 +4,7 @@ import com.salesforce.comdagen.config.AttributeConfig
 import com.salesforce.comdagen.config.GeneratedAttributeConfig
 import com.salesforce.comdagen.config.StoreConfiguration
 import com.salesforce.comdagen.generator.StoreGenerator
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 

--- a/src/test/java/com/salesforce/comdagen/XMLOutputProducerTest.kt
+++ b/src/test/java/com/salesforce/comdagen/XMLOutputProducerTest.kt
@@ -1,42 +1,39 @@
 package com.salesforce.comdagen
 
+import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.core.StringContains.containsString
-import org.junit.Assert.assertThat
-import org.junit.Rule
-import org.junit.Test
-import org.junit.rules.TemporaryFolder
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
 import java.io.File
 import java.io.IOException
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
 
 class XMLOutputProducerTest {
-    @JvmField
-    @Rule
-    var inputFolder = TemporaryFolder()
+    @TempDir
+    lateinit var inputFolder: File
 
-    @JvmField
-    @Rule
-    var outputFolder = TemporaryFolder()
+    @TempDir
+    lateinit var outputFolder: File
 
     @Test
     @Throws(IOException::class)
     fun testOutput() {
         // prepare input directory
         val templateFileName = "test.ftlx"
-        val template = inputFolder.newFile(templateFileName)
+        val template = File(inputFolder, templateFileName)
         Files.copy(
             javaClass.getResourceAsStream("/templates/" + templateFileName), template.toPath(),
             StandardCopyOption.REPLACE_EXISTING
         )
 
-        val outputProducer = XMLOutputProducer(inputFolder.root, outputFolder.root)
+        val outputProducer = XMLOutputProducer(inputFolder, outputFolder)
 
         val modelData = mapOf("title" to "myTITLE")
         // prepare output
         outputProducer.produce(templateFileName, "output.xml", modelData)
 
-        val fileContent = File(outputFolder.root, "output.xml").readText()
+        val fileContent = File(outputFolder, "output.xml").readText()
         // check proper encoding
         assertThat(fileContent, containsString("<title>myTITLE</title>"))
     }
@@ -46,13 +43,13 @@ class XMLOutputProducerTest {
     fun testEncoding() {
         // prepare input directory
         val templateFileName = "test.ftlx"
-        val template = inputFolder.newFile(templateFileName)
+        val template = File(inputFolder, templateFileName)
         Files.copy(
             javaClass.getResourceAsStream("/templates/" + templateFileName), template.toPath(),
             StandardCopyOption.REPLACE_EXISTING
         )
 
-        val outputProducer = XMLOutputProducer(inputFolder.root, outputFolder.root)
+        val outputProducer = XMLOutputProducer(inputFolder, outputFolder)
 
         val modelData = mapOf("title" to "\\\"0\\\" && value<\\\"10\\\" ?\\\"valid\\\":\\\"error\\\"")
 
@@ -60,7 +57,7 @@ class XMLOutputProducerTest {
         outputProducer.produce("test.ftlx", "output.xml", modelData)
 
         // check proper encoding
-        val fileContent = File(outputFolder.root, "output.xml").readText()
+        val fileContent = File(outputFolder, "output.xml").readText()
         assertThat(
             fileContent, containsString(
                 "\\&quot;0\\&quot; &amp;&amp; value&lt;\\&quot;10\\&quot; ?\\&quot;valid\\&quot;:\\&quot;error\\&quot;"


### PR DESCRIPTION
Switch kotlin-test-junit to kotlin-test-junit5 and add junit-jupiter-engine. Replace org.junit.Test with
org.junit.jupiter.api.Test across all test classes, convert @Rule TemporaryFolder to @TempDir File, and port @Test(expected=...) to assertThrows.